### PR TITLE
feat!: pass environment in every method

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
 module github.com/camptocamp/go-puppetca
 
-go 1.14
+go 1.17
+
+require github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
+github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/puppetca/puppetca.go
+++ b/puppetca/puppetca.go
@@ -171,7 +171,7 @@ func (c *Client) Do(req *http.Request, headers map[string]string) (string, error
 	defer resp.Body.Close()
 	content, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
-		return "", errors.Wrapf(err, "failed to read body response from %s")
+		return "", errors.Wrapf(err, "failed to read body response")
 	}
 
 	return string(content), nil

--- a/puppetca/puppetca.go
+++ b/puppetca/puppetca.go
@@ -84,6 +84,15 @@ func (c *Client) GetCertByName(nodename, env string) (string, error) {
 	return pem, nil
 }
 
+// GetRequest return a submitted CSR if any
+func (c *Client) GetRequest(nodename, env string) (string, error) {
+	pem, err := c.Get(fmt.Sprintf("certificate_request/%s", nodename), env, nil)
+	if err != nil {
+		return "", errors.Wrapf(err, "failed to retrieve certificate %s", nodename)
+	}
+	return pem, nil
+}
+
 // DeleteCertByName deletes the certificate of a given node
 func (c *Client) DeleteCertByName(nodename, env string) error {
 	_, err := c.Delete(fmt.Sprintf("certificate_status/%s", nodename), env, nil)


### PR DESCRIPTION
This pull request add the capability to pass puppet environment as query params which allow certificates signing.
On top of that the deps have been update, go version has been bumped to v1.17 and brings one fix.

Regarding puppet environment, this is mandatory when working with puppet server < v6.
While puppet v5 is EoL it is still the default version shipped in common distribution such as Debian 11.